### PR TITLE
gracefully degrade weather if postcode is not populated

### DIFF
--- a/pyhiveapi/pyhiveapi.py
+++ b/pyhiveapi/pyhiveapi.py
@@ -332,8 +332,6 @@ class Pyhiveapi:
 
                 if 'postcode' in api_resp_p['user']:
                     HSC.postcode = api_resp_p['user']['postcode']
-                else:
-                    login_details_found = False
 
                 if 'temperatureUnit' in api_resp_p['user']:
                     HSC.temperature_unit = api_resp_p['user']['temperatureUnit']
@@ -379,7 +377,7 @@ class Pyhiveapi:
                 nodes_updated = Pyhiveapi.hive_api_get_nodes(self, node_id)
 
             weather_last_update_secs = (current_time - HSC.weather.last_update).total_seconds()
-            if weather_last_update_secs >= HSC.update_weather_interval_seconds:
+            if HSC.postcode is not "" and weather_last_update_secs >= HSC.update_weather_interval_seconds:
                 nodes_updated = Pyhiveapi.hive_api_get_weather(self)
         finally:
             self.lock.release()
@@ -852,7 +850,8 @@ class Pyhiveapi:
             if HSC.session_id is not None:
                 HSC.update_node_interval_seconds = hive_node_update_interval
                 Pyhiveapi.hive_api_get_nodes_nl(self)
-                Pyhiveapi.hive_api_get_weather(self)
+                if HSC.postcode is not "":
+                    Pyhiveapi.hive_api_get_weather(self)
 
         device_list_all = {}
         device_list_sensor = []


### PR DESCRIPTION
Hi, figured I'd submit a PR for this - it no longer cancels initialization if the postcode is missing, and before calling the weather function, we check `HSC.postcode is not ""`
Essentially it gracefully degrades the weather update in case hiveapi start adding it again. We can kill it if no one actually uses it anymore
Only tested via the example, which worked with these changes