### PR TITLE
Return None from `get_color` if a coloured light doesn't have a hue

### DIFF
--- a/pyhiveapi/light.py
+++ b/pyhiveapi/light.py
@@ -152,6 +152,8 @@ class Light(Session):
 
         try:
             data = Data.products[device["hiveID"]]
+            if data["state"]["hue"] is None:
+                return final
             state = [
                 (data["state"]["hue"]) / 360,
                 (data["state"]["saturation"]) / 100,


### PR DESCRIPTION
For a coloured light that's in "temperature" mode, the hue key seems to be set but as `None`. This causes `TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'`.

This adds a check for that condition and just returns `None`, as a colour isn't valid for the light at that time.

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
2021-02-14 14:02:25 ERROR (MainThread) [homeassistant.components.light] hive: Error on device update!
Traceback (most recent call last):
  File "/opt/homeassistant/lib64/python3.9/site-packages/homeassistant/helpers/entity_platform.py", line 358, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/opt/homeassistant/lib64/python3.9/site-packages/homeassistant/helpers/entity.py", line 466, in async_device_update
    await task
  File "/home/homeassistant/.homeassistant/custom_components/hive/light.py", line 160, in async_update
    self.device = await self.hive.light.get_light(self.device)
  File "/opt/homeassistant/lib64/python3.9/site-packages/pyhiveapi/light.py", line 59, in get_light
    "hs_color": await self.get_color(device),
  File "/opt/homeassistant/lib64/python3.9/site-packages/pyhiveapi/light.py", line 156, in get_color
    (data["state"]["hue"]) / 360,
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```