### PR TITLE
Remove unasync from runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ botocore>=1.19.10
 requests
 aiohttp
 pyquery
-unasync
 loguru


### PR DESCRIPTION
Based on discussion with @pquentin in https://github.com/python-trio/unasync/issues/82, `unasync` should only be useful at build time