### PR TITLE
Fix for Unnecessary pass

### DIFF
--- a/src/session.py
+++ b/src/session.py
@@ -579,7 +579,6 @@ class HiveSession:
                     eval("self." + code)
                 except (NameError, AttributeError) as e:
                     self.logger.warning(f"Device {product_name} cannot be setup - {e}")
-                    pass
 
             if self.data.products[aProduct]["type"] in hive_type:
                 self.config.mode.append(p["id"])


### PR DESCRIPTION
The best fix is simply to delete the `pass` statement on line 582 inside the `except` block within the `createDevices` coroutine method of the `HiveSession` class. The block will remain valid because it still contains the call to `self.logger.warning(...)` and no further action is required.

- Update file `src/session.py`, removing line 582, making no other changes.
- No imports, definitions, or external library requirements.
- No other code is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._