### PR TITLE
Fix device_login failing when login returns AuthenticationResult directly

### DIFF
--- a/src/api/hive_auth.py
+++ b/src/api/hive_auth.py
@@ -18,6 +18,7 @@ from ..helper.hive_exceptions import (
     HiveInvalidDeviceAuthentication,
     HiveInvalidPassword,
     HiveInvalidUsername,
+    HiveReauthRequired,
 )
 from .hive_api import HiveApi
 
@@ -383,6 +384,12 @@ class HiveAuth:
     def device_login(self):
         """Perform device login instead."""
         login_result = self.login()
+
+        if "AuthenticationResult" in login_result:
+            # Login succeeded without a device challenge (e.g. device tracking
+            # not enforced). Tokens are already valid, return them directly.
+            return login_result
+
         auth_params = self.get_auth_params()
         auth_params["DEVICE_KEY"] = self.device_key
 
@@ -405,6 +412,10 @@ class HiveAuth:
             except botocore.exceptions.EndpointConnectionError as err:
                 if err.__class__.__name__ == "EndpointConnectionError":
                     raise HiveApiError from err
+        elif login_result.get("ChallengeName") == self.SMS_MFA_CHALLENGE:
+            # Account has 2FA enabled and device is not remembered by Cognito.
+            # Automatic re-authentication is not possible without user interaction.
+            raise HiveReauthRequired
         else:
             raise HiveInvalidDeviceAuthentication
 

--- a/src/api/hive_auth_async.py
+++ b/src/api/hive_auth_async.py
@@ -22,6 +22,7 @@ from ..helper.hive_exceptions import (
     HiveInvalidDeviceAuthentication,
     HiveInvalidPassword,
     HiveInvalidUsername,
+    HiveReauthRequired,
 )
 from .hive_api import HiveApi
 
@@ -407,6 +408,12 @@ class HiveAuthAsync:
     async def device_login(self):
         """Perform device login instead."""
         login_result = await self.login()
+
+        if "AuthenticationResult" in login_result:
+            # Login succeeded without a device challenge (e.g. device tracking
+            # not enforced). Tokens are already valid, return them directly.
+            return login_result
+
         auth_params = await self.get_auth_params()
         auth_params["DEVICE_KEY"] = self.device_key
 
@@ -437,6 +444,10 @@ class HiveAuthAsync:
             except botocore.exceptions.EndpointConnectionError as err:
                 if err.__class__.__name__ == "EndpointConnectionError":
                     raise HiveApiError from err
+        elif login_result.get("ChallengeName") == self.SMS_MFA_CHALLENGE:
+            # Account has 2FA enabled and device is not remembered by Cognito.
+            # Automatic re-authentication is not possible without user interaction.
+            raise HiveReauthRequired
         else:
             raise HiveInvalidDeviceAuthentication
 


### PR DESCRIPTION
## Problem

When the stored refresh token expires or becomes invalid, `hiveRefreshTokens`
falls back to `deviceLogin`. This calls `login()` internally, which can return
an `AuthenticationResult` directly (no further challenge) when the Cognito user
pool does not enforce device tracking. The previous code had no handler for this
case, causing it to fall through to `else: raise HiveInvalidDeviceAuthentication`,
which prevents the integration from loading with a misleading error.

Specifically, when I tried to add the Hive integration, it got past the entry of username and password and said the integration had been added. However, it showed in the web page tile as "failed to set up", with an error in the log: "Invalid Refresh Token".

## Fix

- In `device_login()` (both async and sync), return immediately if `login()`
  already contains `AuthenticationResult` — the tokens are valid, no device
  challenge is needed.

- Also handle the `SMS_MFA` challenge case by raising `HiveReauthRequired`
  instead of `HiveInvalidDeviceAuthentication`, so Home Assistant can trigger
  a proper re-auth flow for accounts with 2FA enabled.

## Tested

Verified against a live Hive account where the integration previously failed
to set up with `HiveInvalidDeviceAuthentication` on every restart.