### PR TITLE
chore: simplify Dependabot labels from 'type: dependencies' to 'depen…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "type: dependencies"
+      - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
-      - "type: dependencies"
+      - "dependencies"


### PR DESCRIPTION
…dencies'