### PR TITLE
Cap boto3/botocore to <1.38 for aiobotocore compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3>=1.16.10",
-    "botocore>=1.19.10",
+    "boto3>=1.34,<1.38",
+    "botocore>=1.34,<1.38",
     "requests",
     "aiohttp",
     "pyquery",


### PR DESCRIPTION
Fixes #135.

`boto3` and `botocore` had lower bounds only, so pip pulls them to the newest PyPI release whenever this package is installed. Anything in the same env that uses `aiobotocore` then breaks, because `aiobotocore` pins `botocore` to a narrow range. In Home Assistant that shows up as Cloudflare R2, IDrive e2, and Nice G.O. failing to set up after someone starts the Hive config flow.

`>=1.34,<1.38` keeps pip inside what `aiobotocore 2.21.x` accepts. Bump it when downstream consumers move to `aiobotocore 3.x`.

The unreleased `2.0.0` version still carries the old constraints, so worth landing this before that release ships.