### PR TITLE
refactor: replace try/except KeyError with safe dict.get() for zone c…

### DIFF
--- a/src/helper/hive_helper.py
+++ b/src/helper/hive_helper.py
@@ -157,20 +157,14 @@ class HiveHelper:
         device = product
         product_type = product["type"]
         if product_type in ("heating", "hotwater"):
+            product_zone = product.get("props", {}).get("zone")
             for a_device in self.session.data.devices:
                 if self.session.data.devices[a_device]["type"] in HIVE_TYPES["Thermo"]:
-                    try:
-                        if (
-                            product["props"]["zone"]
-                            == self.session.data.devices[a_device]["props"]["zone"]
-                        ):
-                            device = self.session.data.devices[a_device]
-                    except KeyError as e:
-                        _LOGGER.warning(
-                            "get_device_data - KeyError accessing zone data for device %s: %s",
-                            a_device,
-                            str(e),
-                        )
+                    device_zone = (
+                        self.session.data.devices[a_device].get("props", {}).get("zone")
+                    )
+                    if product_zone and device_zone and product_zone == device_zone:
+                        device = self.session.data.devices[a_device]
         elif product_type == "trvcontrol":
             trv_present = len(product["props"]["trvs"]) > 0
             if trv_present:

--- a/tests/unit/test_remaining_branches.py
+++ b/tests/unit/test_remaining_branches.py
@@ -1167,6 +1167,42 @@ class TestHiveHelperZoneMismatch:
         # The zone mismatch means device was never re-assigned; returns the product
         assert result is product
 
+    def test_trv_without_zone_does_not_log_warning(self, caplog):
+        """TRV devices that omit 'zone' from props are silently skipped (no warning)."""
+        import logging
+
+        helper = HiveHelper(session=MagicMock())
+        helper.session.data = Map(
+            {
+                "devices": {
+                    "trv-1": {
+                        "type": "trv",
+                        "props": {
+                            "online": True
+                        },  # no 'zone' key — current API behaviour
+                    }
+                },
+                "products": {},
+                "actions": {},
+                "user": {},
+                "minMax": {},
+            }
+        )
+
+        product = {
+            "type": "heating",
+            "id": "prod-1",
+            "props": {"zone": "zone-A"},
+        }
+
+        with caplog.at_level(logging.WARNING, logger="apyhiveapi.helper.hive_helper"):
+            result = helper.get_device_data(product)
+
+        assert result is product
+        assert not caplog.records, (
+            f"Unexpected warnings: {[r.getMessage() for r in caplog.records]}"
+        )
+
     def test_zone_match_replaces_device_with_thermostat(self):
         """Matching zones cause device to be replaced with the thermostat entry."""
         helper = HiveHelper(session=MagicMock())


### PR DESCRIPTION
…omparison

- Use .get("props", {}).get("zone") instead of direct key access in get_device_data
- Remove KeyError exception handler and warning log for missing zone data
- Only compare zones when both product_zone and device_zone exist
- Add test verifying TRV devices without zone props are silently skipped