### PR TITLE
Treat pyhive as a synchronous package and add a regression test

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,8 @@
 
 # pylint: skip-file
 # ruff: noqa
-if __name__ == "pyhiveapi":  # pragma: no cover
+# TIM CODE - code generation appears not to fully implement the name change to pyhive - so allow for it
+if __name__ in ( "pyhiveapi", "pyhive"):  # pragma: no cover
     from .api.hive_api import HiveApi as API  # type: ignore[assignment]  # pragma: no cover
     from .api.hive_auth import HiveAuth as Auth  # type: ignore[assignment]  # pragma: no cover
 else:

--- a/tests/e2e/test_pyhive_exposes_sync_classes.py
+++ b/tests/e2e/test_pyhive_exposes_sync_classes.py
@@ -1,0 +1,7 @@
+from pyhive.api.hive_auth import HiveAuth
+from pyhive.api.hive_api import HiveApi
+import pyhive
+
+def test_pyhive_exposes_sync_classes():
+    assert pyhive.Auth is HiveAuth
+    assert pyhive.API is HiveApi


### PR DESCRIPTION
import pyhive currently exposes the asynchronous API because src/__init__.py only checks for __name__ == "pyhiveapi".

This change treats both pyhive and pyhiveapi as synchronous packages so that import pyhive exposes the synchronous HiveAuth and HiveApi classes.

Testing
Added a regression test verifying that pyhive exposes the synchronous classes.
Confirmed the new test fails without this change.
Confirmed the test passes with this change.
Ran the existing test suite successfully.