### PR TITLE
fix: relax boto3/botocore upper-bound pin to avoid dependency conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3>=1.34,<1.38",
-    "botocore>=1.34,<1.38",
+    "boto3>=1.34",
+    "botocore>=1.34",
     "requests",
     "aiohttp",
     "pyquery",


### PR DESCRIPTION
## Summary
- The `<1.38` ceiling on `boto3`/`botocore` was stale and started conflicting with other Home Assistant integrations (e.g. LLM Vision) that require a newer boto3 with no upper bound, causing HA's requirements installer to fail setup entirely with `RequirementsNotFound` for any integration depending on this package.
- The AWS Cognito IdP auth calls this library relies on (`InitiateAuth`/`RespondToAuthChallenge`) are stable across boto3/botocore versions, so there's no need to cap it.

## Test plan
- [x] CI passes (unit tests unaffected by dependency version bump)
- [x] Confirm `pip install` resolves cleanly alongside a newer boto3-pinning integration (e.g. LLM Vision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)